### PR TITLE
Changes to the way Savon handles attributes

### DIFF
--- a/lib/marketingcloudsdk/objects.rb
+++ b/lib/marketingcloudsdk/objects.rb
@@ -303,7 +303,7 @@ module MarketingCloudSDK
 			# If the ID property is specified for the destination then it must be a list import
 			if properties.has_key?('DestinationObject') then
 				if properties['DestinationObject'].has_key?('ID') then
-					properties[:attributes!] = { 'DestinationObject' => { 'xsi:type' => 'tns:List'}}
+					properties['DesintationObject'][:'@xsi:type'] = 'tns:List'
 				end
 			end
 		end

--- a/lib/marketingcloudsdk/soap.rb
+++ b/lib/marketingcloudsdk/soap.rb
@@ -121,8 +121,10 @@ module MarketingCloudSDK
 		def header
 			raise 'Require legacy token for soap header' unless internal_token
 			{
-				'oAuth' => {'oAuthToken' => internal_token},
-				:attributes! => { 'oAuth' => { 'xmlns' => 'http://exacttarget.com' }}
+				'oAuth' => {
+					:'@xmlns' => 'http://exacttarget.com',
+					'oAuthToken' => internal_token
+				}
 			}
 		end
 
@@ -163,7 +165,7 @@ module MarketingCloudSDK
 			message = {}
 			message['Action'] = action
 			message['Definitions'] = {'Definition' => properties}
-			message['Definitions'][:attributes!] = { 'Definition' => { 'xsi:type' => ('tns:' + object_type) }}
+			message['Definitions'][:'@xsi:type'] = 'tns:' + object_type
 
 			soap_request :perform, message
 		end
@@ -181,7 +183,7 @@ module MarketingCloudSDK
 			else
 				message['Configurations'] = {'Configuration' => properties}
 			end
-			message['Configurations'][:attributes!] = { 'Configuration' => { 'xsi:type' => ('tns:' + object_type) }}
+			message['Configurations'][:'@xsi:type'] = 'tns:' + object_type
 
 			soap_request :configure, message
 		end
@@ -205,13 +207,12 @@ module MarketingCloudSDK
 
 			if filter and filter.kind_of? Hash
 				message['Filter'] = filter
-				message[:attributes!] = { 'Filter' => { 'xsi:type' => 'tns:SimpleFilterPart' } }
+				message['Filter'][:'@xsi:type'] = 'tns:SimpleFilterPart'
 
 				if filter.has_key?('LogicalOperator')
-					message[:attributes!] = { 'Filter' => { 'xsi:type' => 'tns:ComplexFilterPart' }}
-					message['Filter'][:attributes!] = {
-						'LeftOperand' => { 'xsi:type' => 'tns:SimpleFilterPart' },
-					'RightOperand' => { 'xsi:type' => 'tns:SimpleFilterPart' }}
+					message['Filter'][:'@xsi:type'] = 'tns:ComplexFilterPart'
+					message['Filter']['LeftOperand']['@xsi:type'] = 'tns:SimpleFilterPart'
+					message['Filter']['RightOperand']['@xsi:type'] = 'tns:SimpleFilterPart'
 				end
 			end
 			message = {'RetrieveRequest' => message}
@@ -257,10 +258,13 @@ module MarketingCloudSDK
 			#   end
 			#
 
-			message = {
-				'Objects' => properties,
-				:attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + object_type) } }
-			}
+			message = {'Objects' => properties}
+
+			if properties.is_a? Array
+				properties.each { |p| p[:'@xsi:type'] = ('tns:' + object_type) }
+			else
+				message['Objects'][:'@xsi:type'] = 'tns:' + object_type
+			end
 
 			if upsert
 				message['Options'] = {"SaveOptions" => {"SaveOption" => {"PropertyName"=> "*", "SaveAction" => "UpdateAdd"}}}

--- a/lib/new.rb
+++ b/lib/new.rb
@@ -190,8 +190,10 @@ module MarketingCloudSDK
 
           self.determineStack
 
-          @authObj = {'oAuth' => {'oAuthToken' => @internalAuthToken}}
-          @authObj[:attributes!] = { 'oAuth' => { 'xmlns' => 'http://exacttarget.com' }}
+          @authObj = {'oAuth' => {
+            :@xmlns => 'http://exacttarget.com',
+            'oAuthToken' => @internalAuthToken
+          }}
 
           myWSDL = File.read(@path + '/ExactTargetWSDL.xml')
           @auth = Savon.client(
@@ -257,8 +259,10 @@ module MarketingCloudSDK
             self.determineStack
           end
 
-          @authObj = {'oAuth' => {'oAuthToken' => @internalAuthToken}}
-          @authObj[:attributes!] = { 'oAuth' => { 'xmlns' => 'http://exacttarget.com' }}
+          @authObj = {'oAuth' => {
+            :@xmlns => 'http://exacttarget.com',
+            'oAuthToken' => @internalAuthToken
+          }}
 
           myWSDL = File.read(@path + '/ExactTargetWSDL.xml')
           @auth = Savon.client(
@@ -362,24 +366,20 @@ module MarketingCloudSDK
   end
 
   class ET_Post < ET_Constructor
-    def initialize(authStub, objType, props = nil)
+    def initialize(authStub, objType, props = {})
       @results = []
 
       begin
         authStub.refreshToken
         if props.is_a? Array then
-          obj = {
-            'Objects' => [],
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => [] }
           props.each{ |p|
+            p[':@xsi:type'] = 'tns:' + objType
             obj['Objects'] << p
           }
         else
-          obj = {
-            'Objects' => props,
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => props }
+          obj['Objects']['@xsi:type'] = 'tns:' + objType
         end
 
         response = authStub.auth.call(:create, :message => obj)
@@ -410,18 +410,14 @@ module MarketingCloudSDK
       begin
         authStub.refreshToken
         if props.is_a? Array then
-          obj = {
-            'Objects' => [],
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => [] }
           props.each{ |p|
+            p[':@xsi:type'] = 'tns:' + objType
             obj['Objects'] << p
           }
         else
-          obj = {
-            'Objects' => props,
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => props }
+          obj['Objects']['@xsi:type'] = 'tns:' + objType
         end
 
         response = authStub.auth.call(:delete, :message => obj)
@@ -447,18 +443,14 @@ module MarketingCloudSDK
       begin
         authStub.refreshToken
         if props.is_a? Array then
-          obj = {
-            'Objects' => [],
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => [] }
           props.each{ |p|
+            p[':@xsi:type'] = 'tns:' + objType
             obj['Objects'] << p
            }
         else
-          obj = {
-            'Objects' => props,
-            :attributes! => { 'Objects' => { 'xsi:type' => ('tns:' + objType) } }
-          }
+          obj = { 'Objects' => props }
+          obj['Objects']['@xsi:type'] = 'tns:' + objType
         end
 
         response = authStub.auth.call(:update, :message => obj)
@@ -537,11 +529,12 @@ module MarketingCloudSDK
       if filter then
         if filter.has_key?('LogicalOperator') then
           obj['Filter'] = filter
-          obj[:attributes!] = { 'Filter' => { 'xsi:type' => 'tns:ComplexFilterPart' }}
-          obj['Filter'][:attributes!] = { 'LeftOperand' => { 'xsi:type' => 'tns:SimpleFilterPart' }, 'RightOperand' => { 'xsi:type' => 'tns:SimpleFilterPart' }}
+          obj['Filter'][:'@xsi:type'] = 'tns:ComplexFilterPart'
+          obj['Filter']['LeftOperand'][:'@xsi:type'] = 'tns:SimpleFilterPart'
+          obj['Filter']['RightOperand'][:'@xsi:type'] = 'tns:SimpleFilterPart'
         else
           obj['Filter'] = filter
-          obj[:attributes!] = { 'Filter' => { 'xsi:type' => 'tns:SimpleFilterPart' } }
+          obj['Filter'][:'@xsi:type'] = 'tns:SimpleFilterPart'
         end
       end
 

--- a/marketingcloudsdk.gemspec
+++ b/marketingcloudsdk.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 	spec.add_development_dependency "guard",'~> 1.1'
 	spec.add_development_dependency "guard-rspec",'~> 2.0'
 
-	spec.add_dependency "savon", "2.2.0"
+	spec.add_dependency "savon", "2.11.0"
 	spec.add_dependency "json", "~>1.8",">= 1.8.1" 
 	spec.add_dependency "jwt", "~>1.0",">= 1.0.0"
 end

--- a/spec/soap_spec.rb
+++ b/spec/soap_spec.rb
@@ -41,9 +41,9 @@ describe MarketingCloudSDK::Soap do
       client.internal_token = 'innerspace'
       expect(client.header).to eq(
         {
-          'oAuth' => { 'oAuthToken' => 'innerspace' },
-          :attributes! => {
-            'oAuth' => { 'xmlns' => 'http://exacttarget.com' }
+          'oAuth' => {
+            :@xmlns => 'http://exacttarget.com',
+            'oAuthToken' => 'innerspace'
           }
         }
       )
@@ -76,16 +76,17 @@ describe MarketingCloudSDK::Soap do
       it 'formats soap :create message for single object' do
         expect(subject.soap_post 'Subscriber', 'EmailAddress' => 'test@fuelsdk.com' ).to eq([:create,
           {
-            'Objects' => [{'EmailAddress' => 'test@fuelsdk.com'}],
-            :attributes! => {'Objects' => {'xsi:type' => ('tns:Subscriber')}}
+            'Objects' => [{:'@xsi:type' => 'tns:Subscriber', 'EmailAddress' => 'test@fuelsdk.com'}]
           }])
       end
 
       it 'formats soap :create message for multiple objects' do
         expect(subject.soap_post 'Subscriber', [{'EmailAddress' => 'first@fuelsdk.com'}, {'EmailAddress' => 'second@fuelsdk.com'}] ).to eq([:create,
           {
-            'Objects' => [{'EmailAddress' => 'first@fuelsdk.com'}, {'EmailAddress' => 'second@fuelsdk.com'}],
-            :attributes! => {'Objects' => {'xsi:type' => ('tns:Subscriber')}}
+            'Objects' => [
+              {:'@xsi:type' => 'tns:Subscriber', 'EmailAddress' => 'first@fuelsdk.com'},
+              {:'@xsi:type' => 'tns:Subscriber', 'EmailAddress' => 'second@fuelsdk.com'}
+            ],
           }])
       end
 
@@ -93,10 +94,10 @@ describe MarketingCloudSDK::Soap do
         expect(subject.soap_post 'Subscriber', {'EmailAddress' => 'test@fuelsdk.com', 'Attributes'=> [{'Name'=>'First Name', 'Value'=>'first'}]}).to eq([:create,
           {
             'Objects' => [{
+              :'@xsi:type' => 'tns:Subscriber',
               'EmailAddress' => 'test@fuelsdk.com',
               'Attributes' => [{'Name' => 'First Name', 'Value' => 'first'}],
-            }],
-            :attributes! => {'Objects' => {'xsi:type' => ('tns:Subscriber')}}
+            }]
           }])
       end
 
@@ -110,8 +111,8 @@ describe MarketingCloudSDK::Soap do
                 {'Name' => 'First Name', 'Value' => 'first'},
                 {'Name' => 'Last Name', 'Value' => 'subscriber'},
               ],
-            }],
-            :attributes! => {'Objects' => {'xsi:type' => ('tns:Subscriber')}}
+              :'@xsi:type' => 'tns:Subscriber'
+            }]
           }])
       end
 
@@ -120,19 +121,23 @@ describe MarketingCloudSDK::Soap do
           {'EmailAddress' => 'second@fuelsdk.com', 'Attributes'=> [{'Name'=>'First Name', 'Value'=>'second'}, {'Name'=>'Last Name', 'Value'=>'subscriber'}]}]).to eq([:create,
           {
             'Objects' => [
-              {'EmailAddress' => 'first@fuelsdk.com',
+              {
+                'EmailAddress' => 'first@fuelsdk.com',
                 'Attributes' => [
                   {'Name' => 'First Name', 'Value' => 'first'},
                   {'Name' => 'Last Name', 'Value' => 'subscriber'},
-                ]
+                ],
+                :'@xsi:type' => 'tns:Subscriber'
               },
-              {'EmailAddress' => 'second@fuelsdk.com',
+              {
+                'EmailAddress' => 'second@fuelsdk.com',
                 'Attributes' => [
                   {'Name' => 'First Name', 'Value' => 'second'},
                   {'Name' => 'Last Name', 'Value' => 'subscriber'},
-                ]
-              }],
-            :attributes! => {'Objects' => {'xsi:type' => ('tns:Subscriber')}}
+                ],
+                :'@xsi:type' => 'tns:Subscriber'
+              }
+            ]
           }])
       end
     end


### PR DESCRIPTION
As per https://github.com/savonrb/savon/issues/518, changes to Savon
causes the gem to break in version of Savon beyond 2.2. This is a
first pass at moving all the attribute parsing to the new behavior.